### PR TITLE
add flag to run 'cargo update'

### DIFF
--- a/cmd/cargobump/root.go
+++ b/cmd/cargobump/root.go
@@ -26,6 +26,7 @@ type rootCLIFlags struct {
 	packages  string
 	bumpFile  string
 	cargoRoot string
+	update    bool
 }
 
 var rootFlags rootCLIFlags
@@ -103,7 +104,7 @@ func New() *cobra.Command {
 				return fmt.Errorf("failed to parse Cargo.lock file: %w", err)
 			}
 
-			if err = pkg.Update(patches, pkgs, rootFlags.cargoRoot); err != nil {
+			if err = pkg.Update(patches, pkgs, rootFlags.cargoRoot, rootFlags.update); err != nil {
 				return fmt.Errorf("failed to update packages: %w", err)
 			}
 
@@ -121,6 +122,7 @@ func New() *cobra.Command {
 	flagSet.StringVar(&rootFlags.cargoRoot, "cargoroot", "", "path to the Cargo.lock root")
 	flagSet.StringVar(&rootFlags.packages, "packages", "", "A space-separated list of dependencies to update in form package@version")
 	flagSet.StringVar(&rootFlags.bumpFile, "bump-file", "", "The input file to read dependencies to bump from")
+	flagSet.BoolVar(&rootFlags.update, "run-update", false, "Run 'cargo update' prior upgrading any dependency")
 
 	return cmd
 }

--- a/pkg/run/cargo.go
+++ b/pkg/run/cargo.go
@@ -18,3 +18,12 @@ func CargoUpdatePackage(name, version, cargoRoot string) (string, error) {
 	}
 	return "", nil
 }
+
+func CargoUpdate(cargoRoot string) (string, error) {
+	cmd := exec.Command("cargo", "update") //nolint:gosec
+	cmd.Dir = cargoRoot
+	if bytes, err := cmd.CombinedOutput(); err != nil {
+		return strings.TrimSpace(string(bytes)), err
+	}
+	return "", nil
+}

--- a/pkg/update.go
+++ b/pkg/update.go
@@ -15,7 +15,14 @@ import (
 	"github.com/chainguard-dev/cargobump/pkg/types"
 )
 
-func Update(patches map[string]*types.Package, pkgs []types.CargoPackage, cargoRoot string) error {
+func Update(patches map[string]*types.Package, pkgs []types.CargoPackage, cargoRoot string, update bool) error {
+	// Run 'cargo update' prior upgrading any dependency
+	if update {
+		log.Printf("Running 'cargo update'...\n")
+		if output, err := run.CargoUpdate(cargoRoot); err != nil {
+			return fmt.Errorf("failed to run 'cargo update' '%v' with error: '%w'", output, err)
+		}
+	}
 	for _, p := range pkgs {
 		v, exists := patches[p.Name]
 		if exists {


### PR DESCRIPTION
This adds a flag to run `cargo update` prior upgrading any package.

If we add this flag to the cargobump pipeline, we don't need to run this manual step https://github.com/wolfi-dev/os/pull/36226/files#diff-082830d24d700d64432593b44c0060ede8eade38e132f602ccc51ba40f00911aR34. This would avoid having to run upgrades for certain modules.

```
rustup git:(1.27.1) ✗ ~/chainguard_repos/cargobump/cargobump --run-update --bump-file=cargobump-deps.yaml
2025/01/03 12:30:40 INFO Running 'cargo update'...
2025/01/03 12:30:42 INFO Update package: curl
2025/01/03 12:30:43 INFO Package updated successfully: curl to version 0.4.47
2025/01/03 12:30:43 INFO Update package: url
2025/01/03 12:30:45 INFO Package updated successfully: url to version 2.5.4
```

