### PR TITLE
cli: fix panic error when using --packages flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /cargobump
+bin/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,6 +17,8 @@ linters:
     - unconvert
     - unparam
     - whitespace
+    - nilerr
+    - makezero
   exclusions:
     generated: lax
     presets:

--- a/cmd/cargobump/root_test.go
+++ b/cmd/cargobump/root_test.go
@@ -1,0 +1,42 @@
+package cargobump
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/chainguard-dev/cargobump/pkg/types"
+)
+
+func TestParsePackageList(t *testing.T) {
+	t.Run("happy-path", func(t *testing.T) {
+		got, err := parsePackageList("foo@1.2.3 bar@4.5.6")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := map[string]*types.Package{
+			"foo": {Name: "foo", Version: "1.2.3"},
+			"bar": {Name: "bar", Version: "4.5.6"},
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("mismatch\nwant: %#v\ngot : %#v", want, got)
+		}
+	})
+
+	t.Run("invalid-format", func(t *testing.T) {
+		_, err := parsePackageList("oops-no-at-sign")
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+	})
+
+	t.Run("duplicate-package", func(t *testing.T) {
+		_, err := parsePackageList("foo@1.0.0 foo@2.0.0")
+		if err == nil {
+			t.Fatalf("expected duplicate-package error, got nil")
+		}
+		want := `duplicate package foo@2.0.0 found, already defined as foo@1.0.0`
+		if err.Error() != want {
+			t.Fatalf("unexpected error message:\nwant: %q\ngot : %q", want, err.Error())
+		}
+	})
+}


### PR DESCRIPTION
Fixes https://github.com/chainguard-dev/cargobump/issues/30

Also adds duplicate-package checks, enables new linters.

Ensured this works as expected: `go run . --packages "foo@1.2.3 bar@4.5.6"`