### PR TITLE
fix(ci): add persist-credentials: false and zizmor pedantic config

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,6 +25,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -23,6 +23,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -9,11 +9,15 @@ on:
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - '.github/zizmor.yml'
+      - '.github/dependabot.yml'
   push:
     branches: ['main']
     paths:
       - '.github/workflows/**'
       - '.github/actions/**'
+      - '.github/zizmor.yml'
+      - '.github/dependabot.yml'
 
 permissions: {}
 
@@ -42,3 +46,5 @@ jobs:
 
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          persona: pedantic

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,8 @@
+rules:
+  dependabot-cooldown:
+    config:
+      days: 3
+  anonymous-definition:
+    disable: true
+  concurrency-limits:
+    disable: true


### PR DESCRIPTION

## Summary

This patch series addresses GitHub Actions security findings in `chainguard-dev/cargobump`
as part of the PSEC-923 hardening campaign.

## Patches

### 0001 — `fix(ci): add persist-credentials: false to checkout steps`

Adds `persist-credentials: false` to two `actions/checkout` steps that were missing it:

- `.github/workflows/ci.yaml` — build/test job; no downstream git write operations
- `.github/workflows/golangci-lint.yaml` — lint job; no downstream git write operations

The `zizmor.yaml` and `actionlint.yaml` workflows already had `persist-credentials: false`
on their checkout steps. This patch completes coverage for the remaining two workflows.

Resolves: 2 `artipacked` findings (zizmor)

### 0002 — `fix(ci): add pedantic persona and suppress noisy zizmor rules`

- Creates `.github/zizmor.yml` disabling three pedantic-only rules that have no direct
  security value (`anonymous-definition`, `concurrency-limits`) and configuring
  `dependabot-cooldown` to use a 3-day threshold.
- Updates `.github/workflows/zizmor.yaml` to run zizmor with `persona: pedantic` so
  that all template expansions in `run:` blocks are checked, not just
  attacker-controlled ones.
- Extends the `paths:` trigger in `zizmor.yaml` to include `.github/zizmor.yml` and
  `.github/dependabot.yml`, so that changes to those files trigger the zizmor check.

Resolves: 4 `concurrency-limits` findings, 1 `anonymous-definition` finding,
2 `dependabot-cooldown` findings (all suppressed via config)

## Testing

- Validate that the zizmor workflow runs on PRs touching `.github/zizmor.yml` and
  `.github/dependabot.yml`.
- Confirm zizmor passes in pedantic mode with the new `.github/zizmor.yml` suppression
  config in place.

Refs: PSEC-923